### PR TITLE
Enable async I/O

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 redis = { version = "0.31.0", features = ["tokio-comp"] }
+tokio = { version = "1", features = ["full"] }
 ratatui = { version = "0.29.0", features = ["crossterm"] }
 crossterm = "0.29.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use crate::config::ConnectionProfile;
-use redis::{Client, Connection, Value, ConnectionLike};
+use redis::{aio::Connection, AsyncCommands, Client, Value};
+use tokio::task;
 use std::collections::HashMap;
 use crossclip::{Clipboard, SystemClipboard}; // Changed from crossclip::Clipboard for directness, though original likely worked.
 use fuzzy_matcher::FuzzyMatcher; // Added import
@@ -72,7 +73,7 @@ pub struct App {
 
 impl App {
     // PASTE the two clipboard functions here
-    pub fn copy_selected_key_name_to_clipboard(&mut self) {
+    pub async fn copy_selected_key_name_to_clipboard(&mut self) {
         self.clipboard_status = None; // Clear previous status
         let mut key_to_copy: Option<String> = None;
 
@@ -90,21 +91,24 @@ impl App {
         // The current logic for `display_name` from `visible_keys_in_current_view` should provide the most relevant name.
 
         if let Some(name) = key_to_copy {
-            match SystemClipboard::new() { // Using SystemClipboard directly
-                Ok(clipboard) => { // clipboard needs to be mut for set_string_contents
-                    match clipboard.set_string_contents(name.clone()) {
-                        Ok(_) => self.clipboard_status = Some(format!("Copied key name '{}' to clipboard!", name)),
-                        Err(e) => self.clipboard_status = Some(format!("Failed to copy key name to clipboard: {}", e)),
-                    }
+            let result = task::spawn_blocking(move || {
+                match SystemClipboard::new() {
+                    Ok(clipboard) => clipboard.set_string_contents(name.clone()).map(|_| name),
+                    Err(e) => Err(e),
                 }
-                Err(e) => self.clipboard_status = Some(format!("Failed to access clipboard: {}", e)),
+            }).await;
+
+            match result {
+                Ok(Ok(copied)) => self.clipboard_status = Some(format!("Copied key name '{}' to clipboard!", copied)),
+                Ok(Err(e)) => self.clipboard_status = Some(format!("Failed to access clipboard: {}", e)),
+                Err(e) => self.clipboard_status = Some(format!("Clipboard task failed: {}", e)),
             }
         } else {
             self.clipboard_status = Some("No key selected to copy".to_string());
         }
     }
 
-    pub fn copy_selected_key_value_to_clipboard(&mut self) {
+    pub async fn copy_selected_key_value_to_clipboard(&mut self) {
         self.clipboard_status = None; // Clear previous status
         let mut value_to_copy: Option<String> = None;
 
@@ -153,19 +157,22 @@ impl App {
         }
 
         if let Some(value_str) = value_to_copy {
-            match SystemClipboard::new() {
-                Ok(clipboard) => { 
-                    match clipboard.set_string_contents(value_str.clone()) {
-                        Ok(_) => self.clipboard_status = Some(format!("Copied to clipboard: {}", ellipsize(&value_str, 50))),
-                        Err(e) => self.clipboard_status = Some(format!("Failed to copy value to clipboard: {}", e)),
-                    }
+            let result = task::spawn_blocking(move || {
+                match SystemClipboard::new() {
+                    Ok(clipboard) => clipboard.set_string_contents(value_str.clone()).map(|_| value_str),
+                    Err(e) => Err(e),
                 }
-                Err(e) => self.clipboard_status = Some(format!("Failed to access clipboard: {}", e)),
+            }).await;
+
+            match result {
+                Ok(Ok(copied)) => self.clipboard_status = Some(format!("Copied to clipboard: {}", ellipsize(&copied, 50))),
+                Ok(Err(e)) => self.clipboard_status = Some(format!("Failed to access clipboard: {}", e)),
+                Err(e) => self.clipboard_status = Some(format!("Clipboard task failed: {}", e)),
             }
         } // If value_to_copy is None, a status message should have already been set.
     }
 
-    pub fn new(initial_url: &str, initial_profile_name: &str, profiles: Vec<ConnectionProfile>) -> App {
+    pub async fn new(initial_url: &str, initial_profile_name: &str, profiles: Vec<ConnectionProfile>) -> App {
         let mut app = App {
             selected_db_index: 0,
             db_count: 16, // Default Redis DB count
@@ -218,11 +225,11 @@ impl App {
             app.selected_profile_list_index = app.current_profile_index;
         }
 
-        app.connect_to_profile(app.current_profile_index);
+        app.connect_to_profile(app.current_profile_index).await;
         app
     }
 
-    fn connect_to_profile(&mut self, profile_index: usize) {
+    async fn connect_to_profile(&mut self, profile_index: usize) {
         if profile_index >= self.profiles.len() {
             self.connection_status = format!("Error: Profile index {} out of bounds.", profile_index);
             self.redis_client = None;
@@ -237,19 +244,18 @@ impl App {
         match Client::open(profile.url.as_str()) {
             Ok(client) => {
                 self.redis_client = Some(client);
-                match self.redis_client.as_ref().unwrap().get_connection() {
+                match self.redis_client.as_ref().unwrap().get_async_connection().await {
                     Ok(mut connection) => {
-                        // Select the database
                         let db_to_select = profile.db.unwrap_or(self.selected_db_index as u8);
-                        match redis::cmd("SELECT").arg(db_to_select).query::<()>(&mut connection) {
+                        match redis::cmd("SELECT").arg(db_to_select).query_async::<_, ()>(&mut connection).await {
                             Ok(_) => {
-                                self.selected_db_index = db_to_select as usize; // Ensure app state matches selected DB
+                                self.selected_db_index = db_to_select as usize;
                                 self.redis_connection = Some(connection);
                                 self.connection_status = format!(
                                     "Connected to {} ({}), DB {}",
                                     profile.name, profile.url, self.selected_db_index
                                 );
-                                self.fetch_keys_and_build_tree(); // Fetch keys for the new connection
+                                self.fetch_keys_and_build_tree().await;
                             }
                             Err(e) => {
                                 self.connection_status = format!(
@@ -294,7 +300,7 @@ impl App {
     }
 
     // Fetches all keys from Redis using SCAN and incrementally updates the tree and view.
-    fn fetch_keys_and_build_tree(&mut self) {
+    async fn fetch_keys_and_build_tree(&mut self) {
         self.raw_keys.clear();
         self.key_tree.clear();
         self.current_breadcrumb.clear();
@@ -311,7 +317,7 @@ impl App {
                     .arg(cursor)
                     .arg("MATCH").arg("*")
                     .arg("COUNT").arg(1000)
-                    .query::<(u64, Vec<String>)>(&mut con)
+                    .query_async::<_, (u64, Vec<String>)>(&mut con).await
                 {
                     Ok((next_cursor, batch)) => {
                         cursor = next_cursor;
@@ -407,7 +413,7 @@ impl App {
         }
     }
 
-    pub fn activate_selected_key(&mut self) {
+    pub async fn activate_selected_key(&mut self) {
         if self.selected_visible_key_index < self.visible_keys_in_current_view.len() {
             let (display_name, is_folder) = self.visible_keys_in_current_view[self.selected_visible_key_index].clone();
             self.clear_selected_key_info(); // Clear previous key's info
@@ -444,7 +450,7 @@ impl App {
 
                     if let Some(mut con) = self.redis_connection.take() {
                         // Try GET first, as it's common
-                        match redis::cmd("GET").arg(&actual_full_key_name).query::<Option<String>>(&mut con) {
+                        match redis::cmd("GET").arg(&actual_full_key_name).query_async::<_, Option<String>>(&mut con).await {
                             Ok(Some(value)) => { // Successfully got a string
                                 self.selected_key_type = Some("string".to_string());
                                 self.selected_key_value = Some(value);
@@ -467,15 +473,15 @@ impl App {
 
                                 if is_wrong_type_error {
                                     // GET failed due to WRONGTYPE, so fetch the actual type
-                                    match redis::cmd("TYPE").arg(&actual_full_key_name).query::<String>(&mut con) {
+                                    match redis::cmd("TYPE").arg(&actual_full_key_name).query_async::<_, String>(&mut con).await {
                                         Ok(key_type) => {
                                             self.selected_key_type = Some(key_type.clone());
                                             match key_type.as_str() {
-                                                "hash" => self.fetch_and_set_hash_value(&actual_full_key_name, &mut con),
-                                                "zset" => self.fetch_and_set_zset_value(&actual_full_key_name, &mut con),
-                                                "list" => self.fetch_and_set_list_value(&actual_full_key_name, &mut con),
-                                                "set" => self.fetch_and_set_set_value(&actual_full_key_name, &mut con),
-                                                "stream" => self.fetch_and_set_stream_value(&actual_full_key_name, &mut con),
+                                                "hash" => self.fetch_and_set_hash_value(&actual_full_key_name, &mut con).await,
+                                                "zset" => self.fetch_and_set_zset_value(&actual_full_key_name, &mut con).await,
+                                                "list" => self.fetch_and_set_list_value(&actual_full_key_name, &mut con).await,
+                                                "set" => self.fetch_and_set_set_value(&actual_full_key_name, &mut con).await,
+                                                "stream" => self.fetch_and_set_stream_value(&actual_full_key_name, &mut con).await,
                                                 _ => {
                                                     self.selected_key_value = Some(format!(
                                                         "Key is of type '{}'. Value view for this type not yet implemented.",
@@ -517,8 +523,8 @@ impl App {
 
     // --- Helper methods for fetching and setting values for specific key types ---
 
-    fn fetch_and_set_hash_value(&mut self, key_name: &str, con: &mut Connection) {
-        match redis::cmd("HGETALL").arg(key_name).query::<Vec<String>>(con) {
+    async fn fetch_and_set_hash_value(&mut self, key_name: &str, con: &mut Connection) {
+        match redis::cmd("HGETALL").arg(key_name).query_async::<_, Vec<String>>(con).await {
             Ok(pairs) => {
                 if pairs.is_empty() { 
                     self.selected_key_value_hash = Some(Vec::new());
@@ -548,8 +554,8 @@ impl App {
         }
     }
 
-    fn fetch_and_set_zset_value(&mut self, key_name: &str, con: &mut Connection) {
-        match redis::cmd("ZRANGE").arg(key_name).arg(0).arg(-1).arg("WITHSCORES").query::<Vec<String>>(con) {
+    async fn fetch_and_set_zset_value(&mut self, key_name: &str, con: &mut Connection) {
+        match redis::cmd("ZRANGE").arg(key_name).arg(0).arg(-1).arg("WITHSCORES").query_async::<_, Vec<String>>(con).await {
             Ok(pairs) => {
                 if pairs.is_empty() { 
                     self.selected_key_value_zset = Some(Vec::new());
@@ -589,8 +595,8 @@ impl App {
         }
     }
 
-    fn fetch_and_set_list_value(&mut self, key_name: &str, con: &mut Connection) {
-        match redis::cmd("LRANGE").arg(key_name).arg(0).arg(-1).query::<Vec<String>>(con) {
+    async fn fetch_and_set_list_value(&mut self, key_name: &str, con: &mut Connection) {
+        match redis::cmd("LRANGE").arg(key_name).arg(0).arg(-1).query_async::<_, Vec<String>>(con).await {
             Ok(elements) => {
                 self.selected_key_value_list = Some(elements);
                 self.selected_key_value = None;
@@ -604,8 +610,8 @@ impl App {
         }
     }
 
-    fn fetch_and_set_set_value(&mut self, key_name: &str, con: &mut Connection) {
-        match redis::cmd("SMEMBERS").arg(key_name).query::<Vec<String>>(con) {
+    async fn fetch_and_set_set_value(&mut self, key_name: &str, con: &mut Connection) {
+        match redis::cmd("SMEMBERS").arg(key_name).query_async::<_, Vec<String>>(con).await {
             Ok(members) => {
                 self.selected_key_value_set = Some(members);
                 self.selected_key_value = None;
@@ -619,7 +625,7 @@ impl App {
         }
     }
 
-    fn fetch_and_set_stream_value(&mut self, key_name: &str, con: &mut Connection) {
+    async fn fetch_and_set_stream_value(&mut self, key_name: &str, con: &mut Connection) {
         const GROUP_NAME: &str = "lazyredis_group"; // Consider making these configurable or dynamic
         const CONSUMER_NAME: &str = "lazyredis_consumer";
 
@@ -627,12 +633,13 @@ impl App {
         // A more robust solution might check the error type specifically for "BUSYGROUP".
         let _ = redis::cmd("XGROUP")
             .arg("CREATE").arg(key_name).arg(GROUP_NAME).arg("$").arg("MKSTREAM")
-            .query::<()>(con); // Error ignored for simplicity here.
+            .query_async::<_, ()>(con).await; // Error ignored for simplicity here.
 
-        match con.req_command(&redis::cmd("XREADGROUP")
+        match redis::cmd("XREADGROUP")
             .arg("GROUP").arg(GROUP_NAME).arg(CONSUMER_NAME)
-            .arg("COUNT").arg(100) // Fetch more entries for a better view
-            .arg("STREAMS").arg(key_name).arg(">")) // Read new messages for this consumer
+            .arg("COUNT").arg(100)
+            .arg("STREAMS").arg(key_name).arg(">")
+            .query_async::<_, Value>(con).await
         {
             Ok(Value::Nil) => {
                 self.selected_key_value_stream = Some(Vec::new()); // No new messages
@@ -873,12 +880,12 @@ impl App {
         }
     }
 
-    pub fn select_profile_and_connect(&mut self) {
+    pub async fn select_profile_and_connect(&mut self) {
         if self.selected_profile_list_index < self.profiles.len() {
             self.current_profile_index = self.selected_profile_list_index;
             self.is_profile_selector_active = false; 
             // The connect_to_profile method will update connection_status and other relevant fields.
-            self.connect_to_profile(self.current_profile_index); 
+            self.connect_to_profile(self.current_profile_index).await;
         }
     }
 
@@ -917,7 +924,7 @@ impl App {
         }
     }
 
-    pub fn next_db(&mut self) {
+    pub async fn next_db(&mut self) {
         if self.db_count > 0 {
             self.selected_db_index = (self.selected_db_index + 1) % (self.db_count as usize);
             self.clear_selected_key_info();
@@ -928,15 +935,15 @@ impl App {
             self.selected_visible_key_index = 0;
             // Re-establish connection or select DB and fetch keys
             if let Some(profile_idx) = self.profiles.iter().position(|p| p.db == Some(self.selected_db_index as u8) || (p.db.is_none() && self.selected_db_index ==0)) {
-                 self.connect_to_profile(profile_idx); // This will eventually call fetch_keys_and_build_tree
+                 self.connect_to_profile(profile_idx).await; // This will eventually call fetch_keys_and_build_tree
             } else {
                 // Attempt to connect to current profile, which should handle DB selection
-                self.connect_to_profile(self.current_profile_index);
+                self.connect_to_profile(self.current_profile_index).await;
             }
         }
     }
 
-    pub fn previous_db(&mut self) {
+    pub async fn previous_db(&mut self) {
         if self.db_count > 0 {
             if self.selected_db_index > 0 {
                 self.selected_db_index -= 1;
@@ -951,9 +958,9 @@ impl App {
             self.selected_visible_key_index = 0;
             // Re-establish connection or select DB and fetch keys
             if let Some(profile_idx) = self.profiles.iter().position(|p| p.db == Some(self.selected_db_index as u8) || (p.db.is_none() && self.selected_db_index ==0)) {
-                 self.connect_to_profile(profile_idx);
+                 self.connect_to_profile(profile_idx).await;
             } else {
-                 self.connect_to_profile(self.current_profile_index);
+                 self.connect_to_profile(self.current_profile_index).await;
             }
         }
     }
@@ -1112,7 +1119,7 @@ impl App {
         }
     }
 
-    pub fn activate_selected_filtered_key(&mut self) {
+    pub async fn activate_selected_filtered_key(&mut self) {
         if self.selected_filtered_key_index < self.filtered_keys_in_current_view.len() {
             let full_key_path = self.filtered_keys_in_current_view[self.selected_filtered_key_index].clone();
             let path_segments: Vec<String> = full_key_path.split(self.key_delimiter).map(|s| s.to_string()).collect();
@@ -1171,7 +1178,7 @@ impl App {
                 if let Some(leaf_name) = leaf_name_if_leaf { // Use the captured leaf_name
                     if let Some(idx) = self.visible_keys_in_current_view.iter().position(|(name, is_folder)| name == &leaf_name && !*is_folder) {
                         self.selected_visible_key_index = idx;
-                        self.activate_selected_key(); // Load its value
+                        self.activate_selected_key().await; // Load its value
                     }
                 }
             } else {

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -1,22 +1,22 @@
 use std::error::Error;
-use redis::{Client, Commands};
+use redis::{AsyncCommands, Client};
 
-pub fn seed_redis_data(redis_url: &str, db_index: u8) -> Result<(), Box<dyn Error>> {
+pub async fn seed_redis_data(redis_url: &str, db_index: u8) -> Result<(), Box<dyn Error>> {
     println!("Connecting to {} (DB {}) to seed data...", redis_url, db_index);
     let client = Client::open(redis_url)?;
-    let mut con = client.get_connection()?;
+    let mut con = client.get_async_connection().await?;
 
-    redis::cmd("SELECT").arg(db_index).query::<()>(&mut con)?;
+    redis::cmd("SELECT").arg(db_index).query_async::<_, ()>(&mut con).await?;
     println!("Selected database {}.", db_index);
 
     println!("Flushing database {}...", db_index);
-    redis::cmd("FLUSHDB").query::<()>(&mut con)?;
+    redis::cmd("FLUSHDB").query_async::<_, ()>(&mut con).await?;
     println!("Database {} flushed.", db_index);
 
     println!("Seeding a large volume of keys...");
 
     for i in 0..1000 {
-        let _: () = con.set(format!("seed:simple:{}", i), format!("Simple value {}", i))?;
+        let _: () = con.set(format!("seed:simple:{}", i), format!("Simple value {}", i)).await?;
     }
     if 1000 % 100 == 0 { println!("Seeded 1000 simple keys...");}
 
@@ -24,7 +24,7 @@ pub fn seed_redis_data(redis_url: &str, db_index: u8) -> Result<(), Box<dyn Erro
         for j in 0..20 {
             for k in 0..10 {
                 let key = format!("seed:level1:{}:level2:{}:key:{}", i, j, k);
-                let _: () = con.set(&key, format!("Value for {}", key))?;
+                let _: () = con.set(&key, format!("Value for {}", key)).await?;
             }
         }
         if (i+1) % 10 == 0 { println!("Seeded hierarchy for level1 up to {}...", i+1); }
@@ -32,9 +32,9 @@ pub fn seed_redis_data(redis_url: &str, db_index: u8) -> Result<(), Box<dyn Erro
     println!("Seeded nested keys (50*20*10 = 10,000 keys).");
 
     for i in 0..100 {
-        let _: () = con.set(format!("seed/path/num_{}", i), format!("Path value {}", i))?;
-        let _: () = con.set(format!("seed.dot.num_{}", i), format!("Dot value {}", i))?;
-        let _: () = con.set(format!("seed-dash-num_{}", i), format!("Dash value {}", i))?;
+        let _: () = con.set(format!("seed/path/num_{}", i), format!("Path value {}", i)).await?;
+        let _: () = con.set(format!("seed.dot.num_{}", i), format!("Dot value {}", i)).await?;
+        let _: () = con.set(format!("seed-dash-num_{}", i), format!("Dash value {}", i)).await?;
     }
     println!("Seeded 300 keys with various delimiters.");
 
@@ -43,7 +43,7 @@ pub fn seed_redis_data(redis_url: &str, db_index: u8) -> Result<(), Box<dyn Erro
         for j in 0..200 {
             fields.push((format!("field_{}", j), format!("value_for_hash_{}_field_{}", i, j)));
         }
-        let _: () = con.hset_multiple(format!("seed:large_hash:{}", i), &fields)?;
+        let _: () = con.hset_multiple(format!("seed:large_hash:{}", i), &fields).await?;
         if (i+1) % 10 == 0 { println!("Seeded large hash {}...", i+1); }
     }
     println!("Seeded 50 large hashes (50 * 200 fields).");
@@ -53,7 +53,7 @@ pub fn seed_redis_data(redis_url: &str, db_index: u8) -> Result<(), Box<dyn Erro
         for j in 0..500 {
             items.push(format!("list_{}_item_{}", i, j));
         }
-        let _: () = con.rpush(format!("seed:large_list:{}", i), items)?;
+        let _: () = con.rpush(format!("seed:large_list:{}", i), items).await?;
         if (i+1) % 10 == 0 { println!("Seeded large list {}...", i+1); }
     }
     println!("Seeded 50 large lists (50 * 500 items).");
@@ -63,7 +63,7 @@ pub fn seed_redis_data(redis_url: &str, db_index: u8) -> Result<(), Box<dyn Erro
         for j in 0..300 {
             members.push(format!("set_{}_member_{}", i, j));
         }
-        let _: () = con.sadd(format!("seed:large_set:{}", i), members)?;
+        let _: () = con.sadd(format!("seed:large_set:{}", i), members).await?;
          if (i+1) % 10 == 0 { println!("Seeded large set {}...", i+1); }
     }
     println!("Seeded 50 large sets (50 * 300 members).");
@@ -73,7 +73,7 @@ pub fn seed_redis_data(redis_url: &str, db_index: u8) -> Result<(), Box<dyn Erro
         for j in 0..400 {
             members_scores.push(((j * 10) as f64, format!("zset_{}_member_{}", i, j)));
         }
-        let _: () = con.zadd_multiple(format!("seed:large_zset:{}", i), &members_scores)?;
+        let _: () = con.zadd_multiple(format!("seed:large_zset:{}", i), &members_scores).await?;
         if (i+1) % 10 == 0 { println!("Seeded large zset {}...", i+1); }
     }
     println!("Seeded 50 large zsets (50 * 400 members/scores).");
@@ -85,31 +85,31 @@ pub fn seed_redis_data(redis_url: &str, db_index: u8) -> Result<(), Box<dyn Erro
                 ("sensor_id", format!("sensor_{}", i % 5)),
                 ("timestamp", (j * 1000).to_string()),
                 ("payload", format!("Some data payload for event {}-{}, could be JSON or any string.", i,j))
-            ])?;
+            ]).await?;
         }
         println!("Seeded stream seed:large_stream:{} with 1000 entries.", i);
     }
     println!("Seeded 10 streams with 1000 entries each.");
     
     println!("Seeding original specific test keys...");
-    let _: () = con.set("seed:string", "Hello from LazyRedis Seeder!")?;
-    let _: () = con.set("seed:another_string", "This string is a bit longer and might require scrolling to see fully in the value panel if it is narrow enough.")?;
-    let _: () = con.hset_multiple("seed:hash", &[("field1", "Value1"), ("field2", "Another Value"), ("long_field_name_for_testing_wrapping", "This value is also quite long to test how wrapping behaves in the TUI for hash values.")])?;
-    let _: () = con.rpush("seed:list", &["Item 1", "Item 2", "Item 3", "Yet another item", "And one more for good measure"])?;
-    let _: () = con.sadd("seed:set", &["MemberA", "MemberB", "MemberC", "MemberD", "MemberE", "MemberA"])?;
-    let _: () = con.zadd_multiple("seed:zset", &[ (10.0, "Ten"), (1.0, "One"), (30.0, "Thirty"), (20.0, "Twenty"), (5.0, "Five"), (100.0, "One Hundred"), (15.0, "Fifteen")])?;
-    let _: String = con.xadd("seed:stream", "*", &[("fieldA", "valueA1"), ("fieldB", "valueB1")])?;
-    let _: String = con.xadd("seed:stream", "*", &[("sensor-id", "1234"), ("temperature", "19.8")])?;
-    let _: String = con.xadd("seed:stream", "*", &[("message", "Hello World"), ("user", "Alice"), ("timestamp", "1678886400000")])?;
+    let _: () = con.set("seed:string", "Hello from LazyRedis Seeder!").await?;
+    let _: () = con.set("seed:another_string", "This string is a bit longer and might require scrolling to see fully in the value panel if it is narrow enough.").await?;
+    let _: () = con.hset_multiple("seed:hash", &[("field1", "Value1"), ("field2", "Another Value"), ("long_field_name_for_testing_wrapping", "This value is also quite long to test how wrapping behaves in the TUI for hash values.")]).await?;
+    let _: () = con.rpush("seed:list", &["Item 1", "Item 2", "Item 3", "Yet another item", "And one more for good measure"]).await?;
+    let _: () = con.sadd("seed:set", &["MemberA", "MemberB", "MemberC", "MemberD", "MemberE", "MemberA"]).await?;
+    let _: () = con.zadd_multiple("seed:zset", &[ (10.0, "Ten"), (1.0, "One"), (30.0, "Thirty"), (20.0, "Twenty"), (5.0, "Five"), (100.0, "One Hundred"), (15.0, "Fifteen")]).await?;
+    let _: String = con.xadd("seed:stream", "*", &[("fieldA", "valueA1"), ("fieldB", "valueB1")]).await?;
+    let _: String = con.xadd("seed:stream", "*", &[("sensor-id", "1234"), ("temperature", "19.8")]).await?;
+    let _: String = con.xadd("seed:stream", "*", &[("message", "Hello World"), ("user", "Alice"), ("timestamp", "1678886400000")]).await?;
     println!("Seeding empty types for testing views...");
-    let _: () = con.hset("seed:empty_hash", "placeholder_field", "placeholder_value")?;
-    let _: i32 = con.hdel("seed:empty_hash", "placeholder_field")?;
-    let _: () = con.rpush("seed:empty_list", "placeholder")?;
-    let _: String = con.lpop("seed:empty_list", Default::default())?;
-    let _: () = con.sadd("seed:empty_set", "placeholder")?;
-    let _: i32 = con.srem("seed:empty_set", "placeholder")?;
-    let _: () = con.zadd("seed:empty_zset", "placeholder", 1.0)?;
-    let _: i32 = con.zrem("seed:empty_zset", "placeholder")?;
+    let _: () = con.hset("seed:empty_hash", "placeholder_field", "placeholder_value").await?;
+    let _: i32 = con.hdel("seed:empty_hash", "placeholder_field").await?;
+    let _: () = con.rpush("seed:empty_list", "placeholder").await?;
+    let _: String = con.lpop::<_, String>("seed:empty_list", Default::default()).await?;
+    let _: () = con.sadd("seed:empty_set", "placeholder").await?;
+    let _: i32 = con.srem("seed:empty_set", "placeholder").await?;
+    let _: () = con.zadd("seed:empty_zset", "placeholder", 1.0).await?;
+    let _: i32 = con.zrem("seed:empty_zset", "placeholder").await?;
 
     println!("Finished seeding data.");
     Ok(())


### PR DESCRIPTION
## Summary
- add the `tokio` runtime
- switch Redis calls to use the async API
- update clipboard helpers to avoid blocking
- convert seeding and purge helpers to async
- wire async calls into the TUI event loop

## Testing
- `cargo check --offline` *(fails: no matching package named `crossclip` found)*
- `uv run pytest` *(fails: `pytest` not found)*