### PR TITLE
Add tests and precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: local
+    hooks:
+      - id: rustfmt
+        name: rustfmt
+        entry: cargo fmt -- --check
+        language: system
+        types: [rust]
+      - id: clippy
+        name: clippy
+        entry: cargo clippy -- -D warnings
+        language: system
+        types: [rust]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,10 +446,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"
@@ -463,9 +511,12 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -488,7 +539,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -689,6 +752,8 @@ dependencies = [
  "ratatui",
  "redis",
  "serde",
+ "serial_test",
+ "tempfile",
  "tokio",
  "toml",
  "url",
@@ -791,7 +856,7 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -957,6 +1022,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "ratatui"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,7 +1085,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror",
 ]
@@ -1064,10 +1135,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "scc"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
 name = "serde"
@@ -1096,6 +1182,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1225,6 +1336,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1415,6 +1539,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +1658,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ fuzzy-matcher = "0.3.7"
 url = "2.5.4"
 
 [dev-dependencies]
+tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ url = "2.5.4"
 
 [dev-dependencies]
 tempfile = "3"
+serial_test = "3.0.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1266,3 +1266,103 @@ fn ellipsize(text: &str, max_len: usize) -> String {
         format!("{}...", &text[..max_len.saturating_sub(3)])
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn empty_app() -> App {
+        App {
+            selected_db_index: 0,
+            db_count: 16,
+            redis_client: None,
+            redis_connection: None,
+            connection_status: String::new(),
+            profiles: Vec::new(),
+            current_profile_index: 0,
+            is_profile_selector_active: false,
+            selected_profile_list_index: 0,
+            raw_keys: Vec::new(),
+            key_tree: HashMap::new(),
+            current_breadcrumb: Vec::new(),
+            visible_keys_in_current_view: Vec::new(),
+            selected_visible_key_index: 0,
+            key_delimiter: ':',
+            is_key_view_focused: false,
+            active_leaf_key_name: None,
+            selected_key_type: None,
+            selected_key_value: None,
+            selected_key_value_hash: None,
+            selected_key_value_zset: None,
+            selected_key_value_list: None,
+            selected_key_value_set: None,
+            selected_key_value_stream: None,
+            is_value_view_focused: false,
+            value_view_scroll: (0, 0),
+            clipboard_status: None,
+            current_display_value: None,
+            displayed_value_lines: None,
+            selected_value_sub_index: 0,
+            is_search_active: false,
+            search_query: String::new(),
+            filtered_keys_in_current_view: Vec::new(),
+            selected_filtered_key_index: 0,
+            show_delete_confirmation_dialog: false,
+            key_to_delete_display_name: None,
+            key_to_delete_full_path: None,
+            prefix_to_delete: None,
+            deletion_is_folder: false,
+        }
+    }
+
+    #[test]
+    fn builds_tree_with_nested_keys() {
+        let mut app = empty_app();
+        app.raw_keys = vec![
+            "foo:bar".to_string(),
+            "foo:baz".to_string(),
+            "foo:qux:1".to_string(),
+            "alpha".to_string(),
+            "beta:g1:h1".to_string(),
+        ];
+        app.parse_keys_to_tree();
+
+        assert!(matches!(
+            app.key_tree.get("alpha").unwrap(),
+            KeyTreeNode::Leaf { full_key_name } if full_key_name == "alpha"
+        ));
+
+        if let KeyTreeNode::Folder(foo_map) = app.key_tree.get("foo").unwrap() {
+            assert!(matches!(
+                foo_map.get("bar").unwrap(),
+                KeyTreeNode::Leaf { full_key_name } if full_key_name == "foo:bar"
+            ));
+            if let KeyTreeNode::Folder(qux_map) = foo_map.get("qux").unwrap() {
+                assert!(matches!(
+                    qux_map.get("1").unwrap(),
+                    KeyTreeNode::Leaf { full_key_name } if full_key_name == "foo:qux:1"
+                ));
+            } else {
+                panic!("qux should be a folder");
+            }
+        } else {
+            panic!("foo should be a folder");
+        }
+    }
+
+    #[test]
+    fn promotes_leaf_to_folder_when_needed() {
+        let mut app = empty_app();
+        app.raw_keys = vec!["foo".to_string(), "foo:bar".to_string()];
+        app.parse_keys_to_tree();
+        if let KeyTreeNode::Folder(map) = app.key_tree.get("foo").unwrap() {
+            assert!(matches!(
+                map.get("bar").unwrap(),
+                KeyTreeNode::Leaf { full_key_name } if full_key_name == "foo:bar"
+            ));
+            assert_eq!(map.len(), 1);
+        } else {
+            panic!("foo should be folder");
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let verb = if args.purge { "Purging" } else { "Seeding" };
         let noun = if args.purge { "keys" } else { "with test data" };
         println!("{} Redis {}...", verb, noun);
-        let app_config = config::Config::load();
+        let app_config = config::Config::load(None);
 
         let target_profile = if let Some(profile_name) = &args.profile {
             app_config
@@ -136,7 +136,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let app_config_tui = config::Config::load();
+    let app_config_tui = config::Config::load(None);
     let (initial_url, initial_profile_name) = if let Some(profile_name) = &args.profile {
         match app_config_tui.profiles.iter().find(|p| &p.name == profile_name) {
             Some(p) => (p.url.clone(), p.name.clone()),


### PR DESCRIPTION
## Summary
- test parsing keys into folder tree
- test config loading logic
- add pre-commit config for rustfmt and clippy
- include tempfile dev dependency

## Testing
- `cargo test --quiet` *(fails: failed to download from crates.io)*
- `uv run pytest -q` *(fails: `pytest` not found)*