### PR TITLE
Refactor app module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "lazyredis"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazyredis"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]
@@ -20,4 +20,3 @@ anyhow = "1"
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3.0.0"
-

--- a/src/app/app_clipboard.rs
+++ b/src/app/app_clipboard.rs
@@ -46,9 +46,9 @@ pub async fn copy_selected_key_value_to_clipboard(app: &mut App) {
 
     if app.is_value_view_focused {
         // Value view is focused: copy the selected sub-item
-        if let Some(lines) = &app.displayed_value_lines {
-            if !lines.is_empty() && app.selected_value_sub_index < lines.len() {
-                value_to_copy = Some(lines[app.selected_value_sub_index].clone());
+        if let Some(lines) = &app.value_viewer.displayed_value_lines {
+            if !lines.is_empty() && app.value_viewer.selected_value_sub_index < lines.len() {
+                value_to_copy = Some(lines[app.value_viewer.selected_value_sub_index].clone());
             } else {
                 app.clipboard_status = Some("No specific value item selected to copy.".to_string());
             }
@@ -57,12 +57,12 @@ pub async fn copy_selected_key_value_to_clipboard(app: &mut App) {
         }
     } else {
         // Key view is focused (or no specific sub-item focus): copy the whole value representation
-        if app.active_leaf_key_name.is_some() {
-            if let Some(lines) = &app.displayed_value_lines {
+        if app.value_viewer.active_leaf_key_name.is_some() {
+            if let Some(lines) = &app.value_viewer.displayed_value_lines {
                 if !lines.is_empty() {
                     value_to_copy = Some(lines.join("\n"));
                 } else {
-                    if let Some(cvd) = &app.current_display_value {
+                    if let Some(cvd) = &app.value_viewer.current_display_value {
                         if !cvd.starts_with("(") || !cvd.ends_with(")") {
                             value_to_copy = Some(cvd.clone());
                         } else {
@@ -72,7 +72,7 @@ pub async fn copy_selected_key_value_to_clipboard(app: &mut App) {
                          app.clipboard_status = Some("No value content to copy (displayed_value_lines is empty).".to_string());
                     }
                 }
-            } else if let Some(s_val) = &app.current_display_value {
+            } else if let Some(s_val) = &app.value_viewer.current_display_value {
                 value_to_copy = Some(s_val.clone());
             } else {
                 app.clipboard_status = Some("No value available to copy for the selected key.".to_string());

--- a/src/app/app_fetch.rs
+++ b/src/app/app_fetch.rs
@@ -1,0 +1,218 @@
+use std::future::Future;
+use redis::{aio::MultiplexedConnection, Value};
+use super::{App, StreamEntry};
+
+impl App {
+
+    async fn run_fetch<T, Fut, OkF, ErrF>(&mut self, fut: Fut, on_ok: OkF, on_err: ErrF, err_msg: String)
+    where
+        Fut: Future<Output = redis::RedisResult<T>>,
+        OkF: FnOnce(&mut Self, T),
+        ErrF: FnOnce(&mut Self),
+    {
+        match fut.await {
+            Ok(val) => {
+                on_ok(self, val);
+                self.selected_key_value = None;
+            }
+            Err(e) => {
+                self.selected_key_value = Some(format!("{}: {}", err_msg, e));
+                on_err(self);
+            }
+        }
+    }
+
+    async fn fetch_and_set_hash_value(&mut self, key_name: &str, con: &mut MultiplexedConnection) {
+        let mut owned_cmd = redis::cmd("HGETALL");
+        owned_cmd.arg(key_name);
+        let fut = owned_cmd.query_async::<Vec<String>>(con);
+        let err_context = format!("Failed to HGETALL for '{}' (hash)", key_name);
+        self.run_fetch(
+            fut,
+            |app, pairs| {
+                if pairs.is_empty() {
+                    app.selected_key_value_hash = Some(Vec::new());
+                } else {
+                    let mut hash_data: Vec<(String, String)> = Vec::new();
+                    for chunk in pairs.chunks(2) {
+                        if chunk.len() == 2 {
+                            hash_data.push((chunk[0].clone(), chunk[1].clone()));
+                        } else {
+                            app.selected_key_value = Some(format!(
+                                "HGETALL for '{}' (hash) returned malformed pair data.",
+                                key_name
+                            ));
+                            app.selected_key_value_hash = None;
+                            return;
+                        }
+                    }
+                    app.selected_key_value_hash = Some(hash_data);
+                }
+            },
+            |app| {
+                app.selected_key_value_hash = None;
+            },
+            err_context,
+        )
+        .await;
+    }
+
+    async fn fetch_and_set_zset_value(&mut self, key_name: &str, con: &mut MultiplexedConnection) {
+        let mut owned_cmd = redis::cmd("ZRANGE");
+        owned_cmd.arg(key_name);
+        owned_cmd.arg(0);
+        owned_cmd.arg(-1);
+        owned_cmd.arg("WITHSCORES");
+        let fut = owned_cmd.query_async::<Vec<String>>(con);
+        let err_context = format!("Failed to ZRANGE for '{}' (zset)", key_name);
+        self.run_fetch(
+            fut,
+            |app, pairs| {
+                if pairs.is_empty() {
+                    app.selected_key_value_zset = Some(Vec::new());
+                } else {
+                    let mut zset_data: Vec<(String, f64)> = Vec::new();
+                    for chunk in pairs.chunks(2) {
+                        if chunk.len() == 2 {
+                            let member = chunk[0].clone();
+                            match chunk[1].parse::<f64>() {
+                                Ok(score) => zset_data.push((member, score)),
+                                Err(_) => {
+                                    app.selected_key_value = Some(format!(
+                                        "ZRANGE for '{}' (zset) failed to parse score for member '{}'.",
+                                        key_name,
+                                        member
+                                    ));
+                                    app.selected_key_value_zset = None;
+                                    return;
+                                }
+                            }
+                        } else {
+                            app.selected_key_value = Some(format!(
+                                "ZRANGE for '{}' (zset) returned malformed pair data.",
+                                key_name
+                            ));
+                            app.selected_key_value_zset = None;
+                            return;
+                        }
+                    }
+                    app.selected_key_value_zset = Some(zset_data);
+                }
+            },
+            |app| {
+                app.selected_key_value_zset = None;
+            },
+            err_context,
+        )
+        .await;
+    }
+
+    async fn fetch_and_set_list_value(&mut self, key_name: &str, con: &mut MultiplexedConnection) {
+        let mut owned_cmd = redis::cmd("LRANGE");
+        owned_cmd.arg(key_name);
+        owned_cmd.arg(0);
+        owned_cmd.arg(-1);
+        let fut = owned_cmd.query_async::<Vec<String>>(con);
+        let err_context = format!("Failed to LRANGE for '{}' (list)", key_name);
+        self.run_fetch(
+            fut,
+            |app, elements| {
+                app.selected_key_value_list = Some(elements);
+            },
+            |app| {
+                app.selected_key_value_list = None;
+            },
+            err_context,
+        )
+        .await;
+    }
+
+    async fn fetch_and_set_set_value(&mut self, key_name: &str, con: &mut MultiplexedConnection) {
+        let mut owned_cmd = redis::cmd("SMEMBERS");
+        owned_cmd.arg(key_name);
+        let fut = owned_cmd.query_async::<Vec<String>>(con);
+        let err_context = format!("Failed to SMEMBERS for '{}' (set)", key_name);
+        self.run_fetch(
+            fut,
+            |app, members| {
+                app.selected_key_value_set = Some(members);
+            },
+            |app| {
+                app.selected_key_value_set = None;
+            },
+            err_context,
+        )
+        .await;
+    }
+
+    async fn fetch_and_set_stream_value(&mut self, key_name: &str, con: &mut MultiplexedConnection) {
+        const GROUP_NAME: &str = "lazyredis_group";
+        const CONSUMER_NAME: &str = "lazyredis_consumer";
+
+        let _ = redis::cmd("XGROUP")
+            .arg("CREATE").arg(key_name).arg(GROUP_NAME).arg("$").arg("MKSTREAM")
+            .query_async::<()>(con).await;
+
+        match redis::cmd("XREADGROUP")
+            .arg("GROUP").arg(GROUP_NAME).arg(CONSUMER_NAME)
+            .arg("COUNT").arg(100)
+            .arg("STREAMS").arg(key_name).arg(">")
+            .query_async::<Value>(con).await
+        {
+            Ok(Value::Nil) => {
+                self.selected_key_value_stream = Some(Vec::new());
+                self.selected_key_value = None;
+                self.current_display_value = Some("(empty stream or no new messages)".to_string());
+                self.displayed_value_lines = None;
+            },
+            Ok(Value::Array(stream_data)) => { 
+                let mut parsed_streams: Vec<StreamEntry> = Vec::new();
+                for single_stream_result in stream_data {
+                    if let Value::Array(stream_specific_data) = single_stream_result {
+                        if stream_specific_data.len() == 2 {
+                            if let Value::Array(messages) = &stream_specific_data[1] {
+                                for message_val in messages {
+                                    if let Value::Array(message_parts) = message_val { 
+                                        if message_parts.len() == 2 {
+                                            if let Value::BulkString(id_bytes) = &message_parts[0] { 
+                                                let id = String::from_utf8_lossy(id_bytes).to_string();
+                                                if let Value::Array(fields_data) = &message_parts[1] {
+                                                    let mut fields = Vec::new();
+                                                    for i in (0..fields_data.len()).step_by(2) {
+                                                        if i + 1 < fields_data.len() {
+                                                            if let (Value::BulkString(f_bytes), Value::BulkString(v_bytes)) = (&fields_data[i], &fields_data[i+1]) {
+                                                                fields.push((
+                                                                    String::from_utf8_lossy(f_bytes).to_string(),
+                                                                    String::from_utf8_lossy(v_bytes).to_string()
+                                                                ));
+                                                            }
+                                                        }
+                                                    }
+                                                    parsed_streams.push(StreamEntry { id, fields });
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                self.selected_key_value_stream = Some(parsed_streams);
+                self.selected_key_value = None;
+                self.update_current_display_value(); 
+            },
+            Ok(other_value) => {
+                self.selected_key_value_stream = None;
+                self.selected_key_value = Some(format!("Unexpected value structure from XREADGROUP: {:?}", other_value));
+                self.update_current_display_value();
+            },
+            Err(e) => {
+                self.selected_key_value_stream = None;
+                self.selected_key_value = Some(format!("Error fetching stream: {}", e));
+                self.update_current_display_value();
+            }
+        }
+    }
+
+}

--- a/src/app/app_fetch.rs
+++ b/src/app/app_fetch.rs
@@ -22,7 +22,7 @@ impl App {
         }
     }
 
-    async fn fetch_and_set_hash_value(&mut self, key_name: &str, con: &mut MultiplexedConnection) {
+    pub async fn fetch_and_set_hash_value(&mut self, key_name: &str, con: &mut MultiplexedConnection) {
         let mut owned_cmd = redis::cmd("HGETALL");
         owned_cmd.arg(key_name);
         let fut = owned_cmd.query_async::<Vec<String>>(con);
@@ -57,7 +57,7 @@ impl App {
         .await;
     }
 
-    async fn fetch_and_set_zset_value(&mut self, key_name: &str, con: &mut MultiplexedConnection) {
+    pub async fn fetch_and_set_zset_value(&mut self, key_name: &str, con: &mut MultiplexedConnection) {
         let mut owned_cmd = redis::cmd("ZRANGE");
         owned_cmd.arg(key_name);
         owned_cmd.arg(0);
@@ -107,7 +107,7 @@ impl App {
         .await;
     }
 
-    async fn fetch_and_set_list_value(&mut self, key_name: &str, con: &mut MultiplexedConnection) {
+    pub async fn fetch_and_set_list_value(&mut self, key_name: &str, con: &mut MultiplexedConnection) {
         let mut owned_cmd = redis::cmd("LRANGE");
         owned_cmd.arg(key_name);
         owned_cmd.arg(0);
@@ -127,7 +127,7 @@ impl App {
         .await;
     }
 
-    async fn fetch_and_set_set_value(&mut self, key_name: &str, con: &mut MultiplexedConnection) {
+    pub async fn fetch_and_set_set_value(&mut self, key_name: &str, con: &mut MultiplexedConnection) {
         let mut owned_cmd = redis::cmd("SMEMBERS");
         owned_cmd.arg(key_name);
         let fut = owned_cmd.query_async::<Vec<String>>(con);
@@ -145,7 +145,7 @@ impl App {
         .await;
     }
 
-    async fn fetch_and_set_stream_value(&mut self, key_name: &str, con: &mut MultiplexedConnection) {
+    pub async fn fetch_and_set_stream_value(&mut self, key_name: &str, con: &mut MultiplexedConnection) {
         const GROUP_NAME: &str = "lazyredis_group";
         const CONSUMER_NAME: &str = "lazyredis_consumer";
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,6 +1,9 @@
 pub mod app_clipboard;
 mod app_fetch;
 pub mod redis_client;
+pub mod value_viewer;
+pub mod state_profile_selector;
+pub mod state_delete_dialog;
 
 // use crate::search::SearchState;
 
@@ -14,7 +17,10 @@ pub use redis::aio::MultiplexedConnection; // Re-export for other modules
 // use tokio::task; // Moved to app_clipboard.rs, check if needed elsewhere here.
 use std::collections::HashMap;
 // use crossclip::{Clipboard, SystemClipboard}; // Moved to app_clipboard.rs
-use crate::app::redis_client::{RedisClient};
+use crate::app::redis_client::RedisClient;
+use crate::app::value_viewer::ValueViewer;
+use crate::app::state_profile_selector::ProfileSelectorState;
+use crate::app::state_delete_dialog::DeleteDialogState;
 // REMOVE: use crate::app::app_fetch::{
 //     fetch_and_set_hash_value,
 //     fetch_and_set_zset_value,
@@ -57,8 +63,7 @@ pub struct App {
     pub connection_status: String,
     pub profiles: Vec<ConnectionProfile>,
     pub current_profile_index: usize,
-    pub is_profile_selector_active: bool,
-    pub selected_profile_list_index: usize,
+    pub profile_state: ProfileSelectorState,
     pub raw_keys: Vec<String>,
     pub key_tree: HashMap<String, KeyTreeNode>,
     pub current_breadcrumb: Vec<String>,
@@ -67,31 +72,18 @@ pub struct App {
     pub type_map: HashMap<String, String>,
     pub selected_visible_key_index: usize,
     pub key_delimiter: char,
-    pub is_key_view_focused: bool, 
-    pub active_leaf_key_name: Option<String>, 
-    pub selected_key_type: Option<String>,    
-    pub selected_key_value: Option<String>,   
-    pub selected_key_value_hash: Option<Vec<(String, String)>>,
-    pub selected_key_value_zset: Option<Vec<(String, f64)>>, 
-    pub selected_key_value_list: Option<Vec<String>>,
-    pub selected_key_value_set: Option<Vec<String>>,
-    pub selected_key_value_stream: Option<Vec<StreamEntry>>,
-    pub is_value_view_focused: bool, 
-    pub value_view_scroll: (u16, u16),    
-    pub clipboard_status: Option<String>, 
-    pub current_display_value: Option<String>, 
-    pub displayed_value_lines: Option<Vec<String>>, 
-    pub selected_value_sub_index: usize, 
+    pub is_key_view_focused: bool,
+    pub value_viewer: ValueViewer,
+    pub is_value_view_focused: bool,
+    pub scan_cursor: u64,
+    pub keys_fully_loaded: bool,
+    pub clipboard_status: Option<String>,
 
     // Fuzzy Search State
     pub search_state: SearchState,
 
     // Delete Confirmation State
-    pub show_delete_confirmation_dialog: bool,
-    pub key_to_delete_display_name: Option<String>,
-    pub key_to_delete_full_path: Option<String>, 
-    pub prefix_to_delete: Option<String>,      
-    pub deletion_is_folder: bool,
+    pub delete_dialog: DeleteDialogState,
 
     // Command prompt state
     pub command_state: CommandState,
@@ -111,8 +103,7 @@ impl App {
             connection_status: format!("Initializing for {} ({})...", initial_profile_name, initial_url),
             profiles,
             current_profile_index: 0, 
-            is_profile_selector_active: false,
-            selected_profile_list_index: 0,
+            profile_state: ProfileSelectorState::default(),
             
             raw_keys: Vec::new(),
             key_tree: HashMap::new(),
@@ -123,30 +114,17 @@ impl App {
             selected_visible_key_index: 0,
             key_delimiter: ':',
             is_key_view_focused: false, 
-            active_leaf_key_name: None, 
-            selected_key_type: None,    
-            selected_key_value: None,   
-            selected_key_value_hash: None,
-            selected_key_value_zset: None, 
-            selected_key_value_list: None,
-            selected_key_value_set: None,
-            selected_key_value_stream: None,
-            is_value_view_focused: false, 
-            value_view_scroll: (0, 0),    
-            clipboard_status: None, 
-            current_display_value: None, 
-            displayed_value_lines: None,
-            selected_value_sub_index: 0,
+            value_viewer: ValueViewer::default(),
+            is_value_view_focused: false,
+            scan_cursor: 0,
+            keys_fully_loaded: false,
+            clipboard_status: None,
 
             // Fuzzy Search State
             search_state: SearchState::new(),
 
             // Delete Confirmation State
-            show_delete_confirmation_dialog: false,
-            key_to_delete_display_name: None,
-            key_to_delete_full_path: None,
-            prefix_to_delete: None,
-            deletion_is_folder: false,
+            delete_dialog: DeleteDialogState::default(),
 
             // Command prompt state
             command_state: CommandState::new(),
@@ -154,8 +132,12 @@ impl App {
         };
 
         if !app.profiles.is_empty() {
-            app.current_profile_index = app.profiles.iter().position(|p| p.url == initial_url).unwrap_or(0);
-            app.selected_profile_list_index = app.current_profile_index;
+            app.current_profile_index = app
+                .profiles
+                .iter()
+                .position(|p| p.url == initial_url)
+                .unwrap_or(0);
+            app.profile_state.selected_index = app.current_profile_index;
             if let Some(db) = app.profiles[app.current_profile_index].db {
                 app.selected_db_index = db as usize;
             }
@@ -183,8 +165,15 @@ impl App {
         self.connection_status = format!("Connecting to {} ({})...", profile.name, profile.url);
         tokio::task::yield_now().await;
 
+        // Determine the target_db_index_override based on use_profile_db
+        let target_db_override = if use_profile_db {
+            None // When using profile_db, no override is needed
+        } else {
+            Some(self.selected_db_index) // When not using profile_db (i.e. manual DB select), pass current app selection
+        };
+
         // Use the new RedisClient abstraction
-        match self.redis.connect_to_profile(profile, use_profile_db).await {
+        match self.redis.connect_to_profile(profile, use_profile_db, target_db_override).await {
             Ok(()) => {
                 self.selected_db_index = self.redis.db_index;
                 self.connection_status = self.redis.connection_status.clone();
@@ -197,19 +186,8 @@ impl App {
     }
 
     pub fn clear_selected_key_info(&mut self) {
-        self.active_leaf_key_name = None;
-        self.selected_key_type = None;
-        self.selected_key_value = None;
-        self.selected_key_value_hash = None;
-        self.selected_key_value_zset = None;
-        self.selected_key_value_list = None;
-        self.selected_key_value_set = None;
-        self.selected_key_value_stream = None;
-        self.value_view_scroll = (0, 0);
+        self.value_viewer.clear();
         self.is_value_view_focused = false;
-        self.current_display_value = None;
-        self.displayed_value_lines = None;
-        self.selected_value_sub_index = 0;
     }
 
     async fn fetch_keys_and_build_tree(&mut self) {
@@ -220,7 +198,10 @@ impl App {
         self.selected_visible_key_index = 0;
         self.clear_selected_key_info();
 
-        let mut cursor: u64 = 0;
+        self.scan_cursor = 0;
+        self.keys_fully_loaded = false;
+
+        let mut cursor: u64 = self.scan_cursor;
         let mut con = match self.redis.connection.take() {
             Some(con) => con,
             None => {
@@ -248,9 +229,12 @@ impl App {
                         self.raw_keys.len(),
                         cursor
                     );
+                    self.scan_cursor = cursor;
                     if cursor == 0 {
+                        self.keys_fully_loaded = true;
                         break;
                     }
+                    tokio::task::yield_now().await;
                 }
                 Err(e) => {
                     self.connection_status = format!("Failed during SCAN: {}", e);
@@ -261,6 +245,12 @@ impl App {
         self.redis.connection = Some(con);
         if self.raw_keys.is_empty() {
             self.connection_status = format!("Connected to DB {}. No keys found.", self.selected_db_index);
+        } else if !self.keys_fully_loaded {
+            self.connection_status = format!(
+                "Connected to DB {}. Loaded {} keys so far...",
+                self.selected_db_index,
+                self.raw_keys.len()
+            );
         } else {
             self.connection_status = format!(
                 "Connected to DB {}. Found {} keys. Displaying {} top-level items.",
@@ -331,8 +321,8 @@ impl App {
                     if let Some(KeyTreeNode::Folder(sub_map)) = current_node_map_for_leaf.get(segment) {
                         current_node_map_for_leaf = sub_map;
                     } else {
-                        self.selected_key_value = Some("Error: Invalid breadcrumb path while finding leaf.".to_string());
-                        self.update_current_display_value();
+                        self.value_viewer.selected_key_value = Some("Error: Invalid breadcrumb path while finding leaf.".to_string());
+                        self.value_viewer.update_current_display_value();
                         return;
                     }
                 }
@@ -343,16 +333,16 @@ impl App {
                         _ => None,
                     });
                 if let Some(actual_full_key_name) = actual_full_key_name_opt {
-                    self.active_leaf_key_name = Some(actual_full_key_name.clone());
-                    self.selected_key_type = Some("fetching...".to_string());
-                    self.selected_value_sub_index = 0;
-                    self.value_view_scroll = (0, 0);
+                    self.value_viewer.active_leaf_key_name = Some(actual_full_key_name.clone());
+                    self.value_viewer.selected_key_type = Some("fetching...".to_string());
+                    self.value_viewer.selected_value_sub_index = 0;
+                    self.value_viewer.value_view_scroll = (0, 0);
                     let mut con = match self.redis.connection.take() {
                         Some(con) => con,
                         None => {
-                            self.selected_key_type = Some("error".to_string());
-                            self.selected_key_value = Some("Error: No Redis connection to fetch key value.".to_string());
-                            self.update_current_display_value();
+                            self.value_viewer.selected_key_type = Some("error".to_string());
+                            self.value_viewer.selected_key_value = Some("Error: No Redis connection to fetch key value.".to_string());
+                            self.value_viewer.update_current_display_value();
                             return;
                         }
                     };
@@ -363,12 +353,12 @@ impl App {
                     self.type_map.insert(actual_full_key_name.clone(), key_type.clone());
                     match redis::cmd("GET").arg(&actual_full_key_name).query_async::<Option<String>>(&mut con).await {
                         Ok(Some(value)) => {
-                            self.selected_key_type = Some("string".to_string());
-                            self.selected_key_value = Some(value);
+                            self.value_viewer.selected_key_type = Some("string".to_string());
+                            self.value_viewer.selected_key_value = Some(value);
                         }
                         Ok(None) => {
-                            self.selected_key_type = Some("string".to_string());
-                            self.selected_key_value = Some("(nil)".to_string());
+                            self.value_viewer.selected_key_type = Some("string".to_string());
+                            self.value_viewer.selected_key_value = Some("(nil)".to_string());
                         }
                         Err(e_get) => {
                             let mut is_wrong_type_error = false;
@@ -384,7 +374,7 @@ impl App {
                             if is_wrong_type_error {
                                 match redis::cmd("TYPE").arg(&actual_full_key_name).query_async::<String>(&mut con).await {
                                     Ok(key_type) => {
-                                        self.selected_key_type = Some(key_type.clone());
+                                        self.value_viewer.selected_key_type = Some(key_type.clone());
                                         match key_type.as_str() {
                                             "hash" => self.fetch_and_set_hash_value(&actual_full_key_name, &mut con).await,
                                             "zset" => self.fetch_and_set_zset_value(&actual_full_key_name, &mut con).await,
@@ -392,7 +382,7 @@ impl App {
                                             "set" => self.fetch_and_set_set_value(&actual_full_key_name, &mut con).await,
                                             "stream" => self.fetch_and_set_stream_value(&actual_full_key_name, &mut con).await,
                                             _ => {
-                                                self.selected_key_value = Some(format!(
+                                                self.value_viewer.selected_key_value = Some(format!(
                                                     "Key is of type '{}'. Value view for this type not yet implemented.",
                                                     key_type
                                                 ));
@@ -400,16 +390,16 @@ impl App {
                                         }
                                     }
                                     Err(e_type) => {
-                                        self.selected_key_type = Some("error (TYPE failed)".to_string());
-                                        self.selected_key_value = Some(format!(
+                                        self.value_viewer.selected_key_type = Some("error (TYPE failed)".to_string());
+                                        self.value_viewer.selected_key_value = Some(format!(
                                             "GET for '{}' failed (WRONGTYPE). Subsequent TYPE command also failed: {}",
                                             actual_full_key_name, e_type
                                         ));
                                     }
                                 }
                             } else {
-                                self.selected_key_type = Some("error (GET failed)".to_string());
-                                self.selected_key_value = Some(format!(
+                                self.value_viewer.selected_key_type = Some("error (GET failed)".to_string());
+                                self.value_viewer.selected_key_value = Some(format!(
                                     "Failed to GET key '{}': {} (Kind: {:?}, Code: {:?})",
                                     actual_full_key_name, e_get, e_get.kind(), e_get.code()
                                 ));
@@ -418,111 +408,12 @@ impl App {
                     }
                     self.redis.connection = Some(con);
                 } else {
-                    self.selected_key_type = Some("error".to_string());
-                    self.selected_key_value = Some(format!("Error: Key '{}' not found as leaf in tree at current level after traversal.", display_name));
+                    self.value_viewer.selected_key_type = Some("error".to_string());
+                    self.value_viewer.selected_key_value = Some(format!("Error: Key '{}' not found as leaf in tree at current level after traversal.", display_name));
                 }
             }
         }
-        self.update_current_display_value();
-    }
-
-    fn update_current_display_value(&mut self) {
-        self.current_display_value = None; 
-        self.displayed_value_lines = None; 
-        self.selected_value_sub_index = 0; 
-        self.value_view_scroll = (0,0); 
-
-        if self.selected_key_type.as_deref() == Some("hash") {
-            if let Some(hash_data) = &self.selected_key_value_hash {
-                if hash_data.is_empty() {
-                    self.current_display_value = Some("(empty hash)".to_string());
-                } else {
-                    self.displayed_value_lines = Some(
-                        hash_data
-                            .iter()
-                            .map(|(k, v)| format!("{}: {}", k, v))
-                            .collect::<Vec<String>>(),
-                    );
-                }
-            } else {
-                self.current_display_value = self.selected_key_value.clone(); 
-            }
-        } else if self.selected_key_type.as_deref() == Some("zset") {
-            if let Some(zset_data) = &self.selected_key_value_zset {
-                if zset_data.is_empty() {
-                    self.current_display_value = Some("(empty zset)".to_string());
-                } else {
-                    self.displayed_value_lines = Some(
-                        zset_data
-                            .iter()
-                            .map(|(member, score)| format!("Score: {} - Member: {}", score, member))
-                            .collect::<Vec<String>>(),
-                    );
-                }
-            } else {
-                self.current_display_value = self.selected_key_value.clone(); 
-            }
-        } else if self.selected_key_type.as_deref() == Some("list") { 
-            if let Some(list_data) = &self.selected_key_value_list {
-                if list_data.is_empty() {
-                    self.current_display_value = Some("(empty list)".to_string());
-                } else {
-                    self.displayed_value_lines = Some(
-                        list_data
-                            .iter()
-                            .enumerate()
-                            .map(|(idx, val)| format!("{}: {}", idx, val))
-                            .collect::<Vec<String>>(),
-                    );
-                }
-            } else {
-                self.current_display_value = self.selected_key_value.clone(); 
-            }
-        } else if self.selected_key_type.as_deref() == Some("set") { 
-            if let Some(set_data) = &self.selected_key_value_set {
-                if set_data.is_empty() {
-                    self.current_display_value = Some("(empty set)".to_string());
-                } else {
-                    let mut sorted_set_data = set_data.clone();
-                    sorted_set_data.sort_unstable(); 
-                    self.displayed_value_lines = Some(
-                        sorted_set_data
-                            .iter()
-                            .map(|val| format!("- {}", val))
-                            .collect::<Vec<String>>(),
-                    );
-                }
-            } else {
-                self.current_display_value = self.selected_key_value.clone(); 
-            }
-        } else if self.selected_key_type.as_deref() == Some("stream") { 
-            if let Some(stream_entries) = &self.selected_key_value_stream {
-                if stream_entries.is_empty() {
-                    self.current_display_value = Some("(empty stream or an error occurred fetching entries)".to_string());
-                } else {
-                    let mut lines: Vec<String> = Vec::new();
-                    for entry in stream_entries {
-                        lines.push(format!("ID: {}", entry.id));
-                        if entry.fields.is_empty(){
-                            lines.push("  (no fields)".to_string());
-                        } else {
-                            for (field, value) in &entry.fields {
-                                lines.push(format!("  {}: {}", field, value));
-                            }
-                        }
-                        lines.push("---".to_string()); 
-                    }
-                    if lines.last().map_or(false, |l| l == "---") { 
-                        lines.pop();
-                    }
-                    self.displayed_value_lines = Some(lines);
-                }
-            } else {
-                self.current_display_value = self.selected_key_value.clone();
-            }
-        } else {
-            self.current_display_value = self.selected_key_value.clone();
-        }
+        self.value_viewer.update_current_display_value();
     }
 
     pub fn navigate_key_tree_up(&mut self) {
@@ -567,32 +458,21 @@ impl App {
     }
 
     pub fn toggle_profile_selector(&mut self) {
-        self.is_profile_selector_active = !self.is_profile_selector_active;
-        if self.is_profile_selector_active {
-            self.selected_profile_list_index = self.current_profile_index;
-        }
+        self.profile_state.toggle(self.current_profile_index);
     }
 
     pub fn next_profile_in_list(&mut self) {
-        if !self.profiles.is_empty() {
-            self.selected_profile_list_index = (self.selected_profile_list_index + 1) % self.profiles.len();
-        }
+        self.profile_state.next(self.profiles.len());
     }
 
     pub fn previous_profile_in_list(&mut self) {
-        if !self.profiles.is_empty() {
-            if self.selected_profile_list_index > 0 {
-                self.selected_profile_list_index -= 1;
-            } else {
-                self.selected_profile_list_index = self.profiles.len() - 1;
-            }
-        }
+        self.profile_state.previous(self.profiles.len());
     }
 
     pub async fn select_profile_and_connect(&mut self) {
-        if self.selected_profile_list_index < self.profiles.len() {
-            self.current_profile_index = self.selected_profile_list_index;
-            self.is_profile_selector_active = false; 
+        if self.profile_state.selected_index < self.profiles.len() {
+            self.current_profile_index = self.profile_state.selected_index;
+            self.profile_state.is_active = false;
             self.connect_to_profile(self.current_profile_index, true).await;
         }
     }
@@ -600,11 +480,13 @@ impl App {
     pub fn cycle_focus_backward(&mut self) {
         if self.is_value_view_focused {
             self.is_value_view_focused = false;
-            self.is_key_view_focused = true;
+            self.is_key_view_focused = false; // DB selector focus
         } else if self.is_key_view_focused {
             self.is_key_view_focused = false;
+            self.is_value_view_focused = true;
         } else { 
-            self.is_value_view_focused = true; 
+            self.is_key_view_focused = true; 
+            self.is_value_view_focused = false;
         }
     }
 
@@ -614,6 +496,7 @@ impl App {
             self.is_value_view_focused = true;
         } else if self.is_value_view_focused {
             self.is_value_view_focused = false;
+            // Now, neither is focused: DB selector focus
         } else { 
             self.is_key_view_focused = true;
         }
@@ -668,45 +551,32 @@ impl App {
     }
 
     pub fn initiate_delete_selected_item(&mut self) {
-        if self.search_state.is_active || self.selected_visible_key_index >= self.visible_keys_in_current_view.len() {
-            return;
-        }
-
-        let (display_name, is_folder) = self.visible_keys_in_current_view[self.selected_visible_key_index].clone();
-        self.key_to_delete_display_name = Some(display_name.clone());
-        self.deletion_is_folder = is_folder;
-
-        if is_folder {
-            let mut prefix_parts = self.current_breadcrumb.clone();
-            prefix_parts.push(display_name.trim_end_matches(self.key_delimiter).to_string()); 
-            self.prefix_to_delete = Some(format!("{}{}", prefix_parts.join(&self.key_delimiter.to_string()), self.key_delimiter));
-            self.key_to_delete_full_path = None;
-        } else {
-            let mut full_key_parts = self.current_breadcrumb.clone();
-            full_key_parts.push(display_name);
-            self.key_to_delete_full_path = Some(full_key_parts.join(&self.key_delimiter.to_string()));
-            self.prefix_to_delete = None;
-        }
-        self.show_delete_confirmation_dialog = true;
+        self.delete_dialog.initiate_delete_selected_item(
+            self.selected_visible_key_index,
+            &self.visible_keys_in_current_view,
+            &self.current_breadcrumb,
+            self.key_delimiter,
+            self.search_state.is_active,
+        );
     }
 
     pub fn cancel_delete_item(&mut self) {
-        self.show_delete_confirmation_dialog = false;
-        self.key_to_delete_display_name = None;
-        self.key_to_delete_full_path = None;
-        self.prefix_to_delete = None;
-        self.deletion_is_folder = false;
+        self.delete_dialog.show_confirmation_dialog = false;
+        self.delete_dialog.key_to_delete_display_name = None;
+        self.delete_dialog.key_to_delete_full_path = None;
+        self.delete_dialog.prefix_to_delete = None;
+        self.delete_dialog.deletion_is_folder = false;
     }
 
     pub async fn confirm_delete_item(&mut self) {
-        let result = if self.deletion_is_folder {
-            if let Some(prefix) = self.prefix_to_delete.clone() {
+        let result = if self.delete_dialog.deletion_is_folder {
+            if let Some(prefix) = self.delete_dialog.prefix_to_delete.clone() {
                 self.delete_redis_prefix_async(&prefix).await
             } else {
                 Err("Prefix to delete was None".to_string())
             }
         } else {
-            if let Some(key_path) = self.key_to_delete_full_path.clone() {
+            if let Some(key_path) = self.delete_dialog.key_to_delete_full_path.clone() {
                 self.delete_redis_key_async(&key_path).await
             } else {
                 Err("Key path to delete was None".to_string())
@@ -718,15 +588,15 @@ impl App {
             Err(e) => self.clipboard_status = Some(format!("Error deleting: {}", e)),
         }
         
-        self.show_delete_confirmation_dialog = false;
-        self.key_to_delete_display_name = None;
-        self.key_to_delete_full_path = None;
-        self.prefix_to_delete = None;
-        self.deletion_is_folder = false;
+        self.delete_dialog.show_confirmation_dialog = false;
+        self.delete_dialog.key_to_delete_display_name = None;
+        self.delete_dialog.key_to_delete_full_path = None;
+        self.delete_dialog.prefix_to_delete = None;
+        self.delete_dialog.deletion_is_folder = false;
 
         self.fetch_keys_and_build_tree().await;
         self.update_visible_keys(); 
-        self.active_leaf_key_name = None; 
+        self.value_viewer.active_leaf_key_name = None;
         self.clear_selected_key_info(); 
     }
 
@@ -844,37 +714,37 @@ impl App {
     }
 
     pub fn select_next_value_item(&mut self) {
-        if let Some(lines) = &self.displayed_value_lines {
+        if let Some(lines) = &self.value_viewer.displayed_value_lines {
             if !lines.is_empty() {
-                self.selected_value_sub_index = (self.selected_value_sub_index + 1) % lines.len();
+                self.value_viewer.selected_value_sub_index = (self.value_viewer.selected_value_sub_index + 1) % lines.len();
             }
         }
     }
 
     pub fn select_previous_value_item(&mut self) {
-        if let Some(lines) = &self.displayed_value_lines {
+        if let Some(lines) = &self.value_viewer.displayed_value_lines {
             if !lines.is_empty() {
-                if self.selected_value_sub_index > 0 {
-                    self.selected_value_sub_index -= 1;
+                if self.value_viewer.selected_value_sub_index > 0 {
+                    self.value_viewer.selected_value_sub_index -= 1;
                 } else {
-                    self.selected_value_sub_index = lines.len() - 1;
+                    self.value_viewer.selected_value_sub_index = lines.len() - 1;
                 }
             }
         }
     }
 
     pub fn select_page_down_value_item(&mut self, page_size: usize) {
-        if let Some(lines) = &self.displayed_value_lines {
+        if let Some(lines) = &self.value_viewer.displayed_value_lines {
             if !lines.is_empty() {
-                self.selected_value_sub_index = (self.selected_value_sub_index + page_size).min(lines.len() - 1);
+                self.value_viewer.selected_value_sub_index = (self.value_viewer.selected_value_sub_index + page_size).min(lines.len() - 1);
             }
         }
     }
 
     pub fn select_page_up_value_item(&mut self, page_size: usize) {
-        if let Some(lines) = &self.displayed_value_lines {
+        if let Some(lines) = &self.value_viewer.displayed_value_lines {
             if !lines.is_empty() {
-                self.selected_value_sub_index = self.selected_value_sub_index.saturating_sub(page_size);
+                self.value_viewer.selected_value_sub_index = self.value_viewer.selected_value_sub_index.saturating_sub(page_size);
             }
         }
     }

--- a/src/app/redis_client.rs
+++ b/src/app/redis_client.rs
@@ -1,0 +1,220 @@
+use redis::{aio::MultiplexedConnection, Client};
+use crate::config::ConnectionProfile;
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum RedisError {
+    Client(redis::RedisError),
+    Connection(String),
+    Other(String),
+}
+
+impl fmt::Display for RedisError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RedisError::Client(e) => write!(f, "Redis client error: {}", e),
+            RedisError::Connection(msg) => write!(f, "Connection error: {}", msg),
+            RedisError::Other(msg) => write!(f, "Other error: {}", msg),
+        }
+    }
+}
+
+impl Error for RedisError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            RedisError::Client(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<redis::RedisError> for RedisError {
+    fn from(e: redis::RedisError) -> Self {
+        RedisError::Client(e)
+    }
+}
+
+pub struct RedisClient {
+    pub client: Option<Client>,
+    pub connection: Option<MultiplexedConnection>,
+    pub db_index: usize,
+    pub connection_status: String,
+}
+
+impl RedisClient {
+    pub fn new() -> Self {
+        Self {
+            client: None,
+            connection: None,
+            db_index: 0,
+            connection_status: String::from("Not connected"),
+        }
+    }
+
+    pub async fn connect_to_profile(
+        &mut self,
+        profile: &ConnectionProfile,
+        use_profile_db: bool,
+    ) -> Result<(), RedisError> {
+        self.connection_status = format!("Connecting to {} ({})...", profile.name, profile.url);
+        let client = Client::open(profile.url.as_str())?;
+        self.client = Some(client);
+        let mut connection = self
+            .client
+            .as_ref()
+            .unwrap()
+            .get_multiplexed_async_connection()
+            .await?;
+        let db_to_select = if use_profile_db {
+            profile.db.unwrap_or(self.db_index as u8)
+        } else {
+            self.db_index as u8
+        };
+        redis::cmd("SELECT")
+            .arg(db_to_select)
+            .query_async::<()>(&mut connection)
+            .await?;
+        self.db_index = db_to_select as usize;
+        self.connection = Some(connection);
+        self.connection_status = format!(
+            "Connected to {} ({}), DB {}",
+            profile.name, profile.url, self.db_index
+        );
+        Ok(())
+    }
+
+    pub async fn fetch_keys(&mut self) -> Result<Vec<String>, RedisError> {
+        let mut keys = Vec::new();
+        if let Some(mut con) = self.connection.take() {
+            let mut cursor: u64 = 0;
+            loop {
+                match redis::cmd("SCAN")
+                    .arg(cursor)
+                    .arg("MATCH")
+                    .arg("*")
+                    .arg("COUNT")
+                    .arg(1000)
+                    .query_async::<(u64, Vec<String>)>(&mut con)
+                    .await
+                {
+                    Ok((next_cursor, batch)) => {
+                        cursor = next_cursor;
+                        keys.extend(batch);
+                        if cursor == 0 {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        self.connection = Some(con);
+                        return Err(RedisError::Client(e));
+                    }
+                }
+            }
+            self.connection = Some(con);
+            Ok(keys)
+        } else {
+            Err(RedisError::Connection(
+                "No Redis connection available to fetch keys.".to_string(),
+            ))
+        }
+    }
+
+    pub async fn delete_prefix(&mut self, prefix: &str, delimiter: char) -> Result<usize, RedisError> {
+        if let Some(mut con) = self.connection.clone() {
+            let pattern = format!("{}{}", prefix, if prefix.ends_with(delimiter) { "*" } else { "*" });
+            let mut keys_to_delete: Vec<String> = Vec::new();
+            let mut cursor: u64 = 0;
+            loop {
+                match redis::cmd("SCAN")
+                    .arg(cursor)
+                    .arg("MATCH")
+                    .arg(&pattern)
+                    .arg("COUNT")
+                    .arg(100)
+                    .query_async::<(u64, Vec<String>)>(&mut con)
+                    .await
+                {
+                    Ok((next_cursor, batch)) => {
+                        keys_to_delete.extend(batch);
+                        if next_cursor == 0 {
+                            break;
+                        }
+                        cursor = next_cursor;
+                    }
+                    Err(e) => return Err(RedisError::Client(e)),
+                }
+            }
+            if keys_to_delete.is_empty() {
+                return Ok(0);
+            }
+            let count = redis::cmd("DEL")
+                .arg(keys_to_delete.as_slice())
+                .query_async::<i32>(&mut con)
+                .await?;
+            Ok(count as usize)
+        } else {
+            Err(RedisError::Connection(
+                "No Redis connection available for deleting prefix.".to_string(),
+            ))
+        }
+    }
+
+    pub async fn delete_key(&mut self, key: &str) -> Result<bool, RedisError> {
+        if let Some(mut con) = self.connection.clone() {
+            let count = redis::cmd("DEL")
+                .arg(key)
+                .query_async::<i32>(&mut con)
+                .await?;
+            Ok(count > 0)
+        } else {
+            Err(RedisError::Connection(
+                "No Redis connection available for deleting key.".to_string(),
+            ))
+        }
+    }
+
+    pub async fn get_key_type(&mut self, key: &str) -> Result<String, RedisError> {
+        if let Some(mut con) = self.connection.clone() {
+            let key_type = redis::cmd("TYPE")
+                .arg(key)
+                .query_async::<String>(&mut con)
+                .await?;
+            Ok(key_type)
+        } else {
+            Err(RedisError::Connection(
+                "No Redis connection available for key type.".to_string(),
+            ))
+        }
+    }
+
+    pub async fn get_ttl(&mut self, key: &str) -> Result<i64, RedisError> {
+        if let Some(mut con) = self.connection.clone() {
+            let ttl = redis::cmd("TTL")
+                .arg(key)
+                .query_async::<i64>(&mut con)
+                .await?;
+            Ok(ttl)
+        } else {
+            Err(RedisError::Connection(
+                "No Redis connection available for TTL.".to_string(),
+            ))
+        }
+    }
+
+    pub async fn get_string(&mut self, key: &str) -> Result<Option<String>, RedisError> {
+        if let Some(mut con) = self.connection.clone() {
+            let value = redis::cmd("GET")
+                .arg(key)
+                .query_async::<Option<String>>(&mut con)
+                .await?;
+            Ok(value)
+        } else {
+            Err(RedisError::Connection(
+                "No Redis connection available for GET.".to_string(),
+            ))
+        }
+    }
+
+    // Add more methods for hash, list, set, zset, stream as needed
+} 

--- a/src/app/redis_client.rs
+++ b/src/app/redis_client.rs
@@ -56,6 +56,7 @@ impl RedisClient {
         &mut self,
         profile: &ConnectionProfile,
         use_profile_db: bool,
+        target_db_index_override: Option<usize>,
     ) -> Result<(), RedisError> {
         self.connection_status = format!("Connecting to {} ({})...", profile.name, profile.url);
         let client = Client::open(profile.url.as_str())?;
@@ -69,7 +70,7 @@ impl RedisClient {
         let db_to_select = if use_profile_db {
             profile.db.unwrap_or(self.db_index as u8)
         } else {
-            self.db_index as u8
+            target_db_index_override.unwrap_or(self.db_index) as u8
         };
         redis::cmd("SELECT")
             .arg(db_to_select)

--- a/src/app/state_delete_dialog.rs
+++ b/src/app/state_delete_dialog.rs
@@ -1,0 +1,46 @@
+#[derive(Debug, Default, Clone)]
+pub struct DeleteDialogState {
+    pub show_confirmation_dialog: bool,
+    pub key_to_delete_display_name: Option<String>,
+    pub key_to_delete_full_path: Option<String>,
+    pub prefix_to_delete: Option<String>,
+    pub deletion_is_folder: bool,
+}
+
+impl DeleteDialogState {
+    pub fn initiate_delete_selected_item(
+        &mut self,
+        selected_index: usize,
+        visible_keys: &[(String, bool)],
+        current_breadcrumb: &[String],
+        key_delimiter: char,
+        search_active: bool,
+    ) {
+        if search_active || selected_index >= visible_keys.len() {
+            return;
+        }
+        let (display_name, is_folder) = visible_keys[selected_index].clone();
+        self.key_to_delete_display_name = Some(display_name.clone());
+        self.deletion_is_folder = is_folder;
+        if is_folder {
+            let mut prefix_parts = current_breadcrumb.to_vec();
+            prefix_parts.push(display_name.trim_end_matches(key_delimiter).to_string());
+            self.prefix_to_delete = Some(format!("{}{}", prefix_parts.join(&key_delimiter.to_string()), key_delimiter));
+            self.key_to_delete_full_path = None;
+        } else {
+            let mut full_key_parts = current_breadcrumb.to_vec();
+            full_key_parts.push(display_name);
+            self.key_to_delete_full_path = Some(full_key_parts.join(&key_delimiter.to_string()));
+            self.prefix_to_delete = None;
+        }
+        self.show_confirmation_dialog = true;
+    }
+
+    pub fn cancel_delete_item(&mut self) {
+        self.show_confirmation_dialog = false;
+        self.key_to_delete_display_name = None;
+        self.key_to_delete_full_path = None;
+        self.prefix_to_delete = None;
+        self.deletion_is_folder = false;
+    }
+}

--- a/src/app/state_profile_selector.rs
+++ b/src/app/state_profile_selector.rs
@@ -1,0 +1,30 @@
+#[derive(Debug, Default, Clone)]
+pub struct ProfileSelectorState {
+    pub is_active: bool,
+    pub selected_index: usize,
+}
+
+impl ProfileSelectorState {
+    pub fn toggle(&mut self, current_profile_index: usize) {
+        self.is_active = !self.is_active;
+        if self.is_active {
+            self.selected_index = current_profile_index;
+        }
+    }
+
+    pub fn next(&mut self, profiles_len: usize) {
+        if profiles_len > 0 {
+            self.selected_index = (self.selected_index + 1) % profiles_len;
+        }
+    }
+
+    pub fn previous(&mut self, profiles_len: usize) {
+        if profiles_len > 0 {
+            if self.selected_index > 0 {
+                self.selected_index -= 1;
+            } else {
+                self.selected_index = profiles_len - 1;
+            }
+        }
+    }
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1,0 +1,102 @@
+#[cfg(test)]
+
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn empty_app() -> App {
+        App {
+            selected_db_index: 0,
+            db_count: 16,
+            redis_client: None,
+            redis_connection: None,
+            connection_status: String::new(),
+            profiles: Vec::new(),
+            current_profile_index: 0,
+            is_profile_selector_active: false,
+            selected_profile_list_index: 0,
+            raw_keys: Vec::new(),
+            key_tree: HashMap::new(),
+            current_breadcrumb: Vec::new(),
+            visible_keys_in_current_view: Vec::new(),
+            ttl_map: HashMap::new(),
+            type_map: HashMap::new(),
+            selected_visible_key_index: 0,
+            key_delimiter: ':',
+            is_key_view_focused: false, 
+            active_leaf_key_name: None, 
+            selected_key_type: None,    
+            selected_key_value: None,   
+            selected_key_value_hash: None,
+            selected_key_value_zset: None, 
+            selected_key_value_list: None,
+            selected_key_value_set: None,
+            selected_key_value_stream: None,
+            is_value_view_focused: false, 
+            value_view_scroll: (0, 0),    
+            clipboard_status: None, 
+            current_display_value: None, 
+            displayed_value_lines: None,
+            selected_value_sub_index: 0,
+            search_state: SearchState::new(),
+            show_delete_confirmation_dialog: false,
+            key_to_delete_display_name: None,
+            key_to_delete_full_path: None,
+            prefix_to_delete: None,
+            deletion_is_folder: false,
+            command_state: CommandState::new(),
+            pending_operation: None,
+        }
+    }
+
+    #[test]
+    fn builds_tree_with_nested_keys() {
+        let mut app = empty_app();
+        app.raw_keys = vec![
+            "foo:bar".to_string(),
+            "foo:baz".to_string(),
+            "foo:qux:1".to_string(),
+            "alpha".to_string(),
+            "beta:g1:h1".to_string(),
+        ];
+        app.parse_keys_to_tree();
+
+        assert!(matches!(
+            app.key_tree.get("alpha").unwrap(),
+            KeyTreeNode::Leaf { full_key_name } if full_key_name == "alpha"
+        ));
+
+        if let KeyTreeNode::Folder(foo_map) = app.key_tree.get("foo").unwrap() {
+            assert!(matches!(
+                foo_map.get("bar").unwrap(),
+                KeyTreeNode::Leaf { full_key_name } if full_key_name == "foo:bar"
+            ));
+            if let KeyTreeNode::Folder(qux_map) = foo_map.get("qux").unwrap() {
+                assert!(matches!(
+                    qux_map.get("1").unwrap(),
+                    KeyTreeNode::Leaf { full_key_name } if full_key_name == "foo:qux:1"
+                ));
+            } else {
+                panic!("qux should be a folder");
+            }
+        } else {
+            panic!("foo should be a folder");
+        }
+    }
+
+    #[test]
+    fn promotes_leaf_to_folder_when_needed() {
+        let mut app = empty_app();
+        app.raw_keys = vec!["foo".to_string(), "foo:bar".to_string()];
+        app.parse_keys_to_tree();
+        if let KeyTreeNode::Folder(map) = app.key_tree.get("foo").unwrap() {
+            assert!(matches!(
+                map.get("bar").unwrap(),
+                KeyTreeNode::Leaf { full_key_name } if full_key_name == "foo:bar"
+            ));
+            assert_eq!(map.len(), 1);
+        } else {
+            panic!("foo should be folder");
+        }
+    }
+} 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3,6 +3,9 @@
 mod tests {
     use std::collections::HashMap;
     use crate::app::{App, KeyTreeNode};
+    use crate::app::value_viewer::ValueViewer;
+    use crate::app::state_profile_selector::ProfileSelectorState;
+    use crate::app::state_delete_dialog::DeleteDialogState;
     use crate::search::SearchState;
     use crate::command::CommandState;
     use crate::config::ConnectionProfile;
@@ -15,8 +18,7 @@ mod tests {
             connection_status: String::new(),
             profiles: Vec::new(),
             current_profile_index: 0,
-            is_profile_selector_active: false,
-            selected_profile_list_index: 0,
+            profile_state: ProfileSelectorState::default(),
             raw_keys: Vec::new(),
             key_tree: HashMap::new(),
             current_breadcrumb: Vec::new(),
@@ -26,26 +28,13 @@ mod tests {
             selected_visible_key_index: 0,
             key_delimiter: ':',
             is_key_view_focused: false, 
-            active_leaf_key_name: None, 
-            selected_key_type: None,    
-            selected_key_value: None,   
-            selected_key_value_hash: None,
-            selected_key_value_zset: None, 
-            selected_key_value_list: None,
-            selected_key_value_set: None,
-            selected_key_value_stream: None,
-            is_value_view_focused: false, 
-            value_view_scroll: (0, 0),    
-            clipboard_status: None, 
-            current_display_value: None, 
-            displayed_value_lines: None,
-            selected_value_sub_index: 0,
+            value_viewer: ValueViewer::default(),
+            is_value_view_focused: false,
+            scan_cursor: 0,
+            keys_fully_loaded: false,
+            clipboard_status: None,
             search_state: SearchState::new(),
-            show_delete_confirmation_dialog: false,
-            key_to_delete_display_name: None,
-            key_to_delete_full_path: None,
-            prefix_to_delete: None,
-            deletion_is_folder: false,
+            delete_dialog: DeleteDialogState::default(),
             command_state: CommandState::new(),
             pending_operation: None,
         }

--- a/src/app/value_viewer.rs
+++ b/src/app/value_viewer.rs
@@ -1,0 +1,134 @@
+use crate::app::StreamEntry;
+
+#[derive(Debug, Default, Clone)]
+pub struct ValueViewer {
+    pub active_leaf_key_name: Option<String>,
+    pub selected_key_type: Option<String>,
+    pub selected_key_value: Option<String>,
+    pub selected_key_value_hash: Option<Vec<(String, String)>>,
+    pub selected_key_value_zset: Option<Vec<(String, f64)>>,
+    pub selected_key_value_list: Option<Vec<String>>,
+    pub selected_key_value_set: Option<Vec<String>>,
+    pub selected_key_value_stream: Option<Vec<StreamEntry>>,
+    pub current_display_value: Option<String>,
+    pub displayed_value_lines: Option<Vec<String>>,
+    pub selected_value_sub_index: usize,
+    pub value_view_scroll: (u16, u16),
+}
+
+impl ValueViewer {
+    pub fn clear(&mut self) {
+        self.active_leaf_key_name = None;
+        self.selected_key_type = None;
+        self.selected_key_value = None;
+        self.selected_key_value_hash = None;
+        self.selected_key_value_zset = None;
+        self.selected_key_value_list = None;
+        self.selected_key_value_set = None;
+        self.selected_key_value_stream = None;
+        self.current_display_value = None;
+        self.displayed_value_lines = None;
+        self.selected_value_sub_index = 0;
+        self.value_view_scroll = (0, 0);
+    }
+
+    pub fn update_current_display_value(&mut self) {
+        self.current_display_value = None;
+        self.displayed_value_lines = None;
+        self.selected_value_sub_index = 0;
+        self.value_view_scroll = (0, 0);
+
+        if self.selected_key_type.as_deref() == Some("hash") {
+            if let Some(hash_data) = &self.selected_key_value_hash {
+                if hash_data.is_empty() {
+                    self.current_display_value = Some("(empty hash)".to_string());
+                } else {
+                    self.displayed_value_lines = Some(
+                        hash_data
+                            .iter()
+                            .map(|(k, v)| format!("{}: {}", k, v))
+                            .collect::<Vec<String>>(),
+                    );
+                }
+            } else {
+                self.current_display_value = self.selected_key_value.clone();
+            }
+        } else if self.selected_key_type.as_deref() == Some("zset") {
+            if let Some(zset_data) = &self.selected_key_value_zset {
+                if zset_data.is_empty() {
+                    self.current_display_value = Some("(empty zset)".to_string());
+                } else {
+                    self.displayed_value_lines = Some(
+                        zset_data
+                            .iter()
+                            .map(|(member, score)| format!("Score: {} - Member: {}", score, member))
+                            .collect::<Vec<String>>(),
+                    );
+                }
+            } else {
+                self.current_display_value = self.selected_key_value.clone();
+            }
+        } else if self.selected_key_type.as_deref() == Some("list") {
+            if let Some(list_data) = &self.selected_key_value_list {
+                if list_data.is_empty() {
+                    self.current_display_value = Some("(empty list)".to_string());
+                } else {
+                    self.displayed_value_lines = Some(
+                        list_data
+                            .iter()
+                            .enumerate()
+                            .map(|(idx, val)| format!("{}: {}", idx, val))
+                            .collect::<Vec<String>>(),
+                    );
+                }
+            } else {
+                self.current_display_value = self.selected_key_value.clone();
+            }
+        } else if self.selected_key_type.as_deref() == Some("set") {
+            if let Some(set_data) = &self.selected_key_value_set {
+                if set_data.is_empty() {
+                    self.current_display_value = Some("(empty set)".to_string());
+                } else {
+                    let mut sorted_set_data = set_data.clone();
+                    sorted_set_data.sort_unstable();
+                    self.displayed_value_lines = Some(
+                        sorted_set_data
+                            .iter()
+                            .map(|val| format!("- {}", val))
+                            .collect::<Vec<String>>(),
+                    );
+                }
+            } else {
+                self.current_display_value = self.selected_key_value.clone();
+            }
+        } else if self.selected_key_type.as_deref() == Some("stream") {
+            if let Some(stream_entries) = &self.selected_key_value_stream {
+                if stream_entries.is_empty() {
+                    self.current_display_value = Some("(empty stream or an error occurred fetching entries)".to_string());
+                } else {
+                    let mut lines: Vec<String> = Vec::new();
+                    for entry in stream_entries {
+                        lines.push(format!("ID: {}", entry.id));
+                        if entry.fields.is_empty() {
+                            lines.push("  (no fields)".to_string());
+                        } else {
+                            for (field, value) in &entry.fields {
+                                lines.push(format!("  {}: {}", field, value));
+                            }
+                        }
+                        lines.push("---".to_string());
+                    }
+                    if lines.last().map_or(false, |l| l == "---") {
+                        lines.pop();
+                    }
+                    self.displayed_value_lines = Some(lines);
+                }
+            } else {
+                self.current_display_value = self.selected_key_value.clone();
+            }
+        } else {
+            self.current_display_value = self.selected_key_value.clone();
+        }
+    }
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,7 +257,7 @@ async fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: app::App) -> i
                     // This prevents inputs from interfering with an ongoing async task's state changes
                     // or triggering new operations while one is in progress.
                     if app.pending_operation.is_none() {
-                        if app.is_profile_selector_active {
+                        if app.profile_state.is_active {
                             match key.code {
                                 KeyCode::Char('q') => return Ok(()),
                                 KeyCode::Char('p') | KeyCode::Esc => app.toggle_profile_selector(),
@@ -268,7 +268,7 @@ async fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: app::App) -> i
                                 }
                                 _ => {}
                             }
-                        } else if app.show_delete_confirmation_dialog {
+                        } else if app.delete_dialog.show_confirmation_dialog {
                             match key.code {
                                 KeyCode::Enter => {
                                     app.pending_operation = Some(app::PendingOperation::ConfirmDeleteItem);


### PR DESCRIPTION
## Summary
- refactor app/mod.rs for idiomatic style and brevity
- move fetch helpers into `app_fetch` module
- relocate tests into their own file
- simplify `connect_to_profile` logic

## Testing
- `cargo build` *(fails: Could not download crates)*
- `cargo test` *(fails: Could not download crates)*